### PR TITLE
Add no-console rule to ESLint

### DIFF
--- a/api/actions/api.ts
+++ b/api/actions/api.ts
@@ -53,7 +53,6 @@ export async function serverPost<T>(
   config?: AxiosRequestConfig,
 ): Promise<T | ServerAxiosError> {
   try {
-    console.info(url, data, config);
     const response = await axiosInstance.post<T>(url, data, config);
     return response.data;
   } catch (error) {

--- a/api/actions/google.ts
+++ b/api/actions/google.ts
@@ -22,7 +22,7 @@ export async function serverGoogleOAuthURL(): Promise<string> {
     });
     return url;
   } catch (error) {
-    console.log(`[ERROR][serverGoogleOAuth]: ${error}`);
+    console.error(`[ERROR][serverGoogleOAuth]: ${error}`);
     return "";
   }
 }
@@ -44,7 +44,7 @@ export async function serverGoogleOAuthPayload(code: string): Promise<GoogleOAut
       };
     }
   } catch (error) {
-    console.log(`[ERROR][serverGoogleOAuthPayload]: ${error}`);
+    console.error(`[ERROR][serverGoogleOAuthPayload]: ${error}`);
   }
   return {
     email: "error",

--- a/app/(app)/backoffice/page.tsx
+++ b/app/(app)/backoffice/page.tsx
@@ -46,6 +46,8 @@ function MainPage() {
       const response = await createLesson(lessonData);
 
       if (response) {
+        // this will be removed soon
+        // eslint-disable-next-line no-console
         console.log("Lesson created successfully!");
       } else {
         console.error("Failed to create lesson");

--- a/app/(unauthenticated)/lesson/[id]/page.tsx
+++ b/app/(unauthenticated)/lesson/[id]/page.tsx
@@ -14,7 +14,6 @@ const LessonPage = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  console.info(id);
   useEffect(() => {
     if (!id) return;
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,10 +12,21 @@ export default [
   pluginReact.configs.flat.recommended,
   eslintPluginPrettierRecommended,
   {
+    settings: {
+      react: {
+        version: "detect",
+      },
+    },
     rules: {
       "max-len": ["warn", { code: 120 }],
       "react/react-in-jsx-scope": "off",
       "react/jsx-filename-extension": [2, { extensions: [".jsx", ".tsx"] }],
+      "no-console": [
+        "error",
+        {
+          allow: ["error"],
+        },
+      ],
     },
   },
   {


### PR DESCRIPTION
Allow only `console.error` until we implement error management